### PR TITLE
BeerNode-24 - Added: django-bootstrap4 및 Pillow 환경설정 추가

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -17,6 +17,8 @@
 - python 3.8.7
 - django 3.1.5
 - django-environ 0.4.5
+- django-bootstrap4 2.3.1
+- Pillow 8.1.0
 
 ### django_environment
 - /env/environment_files


### PR DESCRIPTION
djanog-bootstrap4 2.3.1
Pillow 8.1.0

이 외에도 다른 오류가 있었는데, 이건 git의 문제로 확인

resolved #24 