### PR TITLE
BeerNode-77 - Added: Block형 list에 해당 사진 출력

### DIFF
--- a/scraplistapp/templates/scraplistapp/list.html
+++ b/scraplistapp/templates/scraplistapp/list.html
@@ -15,8 +15,6 @@
         }
         .container div {
           width: 100px;
-          height: 150px;
-          background-color: antiquewhite;
           display: flex;
           justify-content: center;
           align-items: center;
@@ -26,6 +24,12 @@
             display:flex;
             flex-direction:row;
             justify-content: center;
+        }
+        img{
+            width: 100px;
+            height: 100px;
+            object-fit: cover;
+            border-radius: 1rem;
         }
     </style>
     <div>
@@ -52,15 +56,10 @@
     </div>
     <div class="block" style="display: none">
         <div class="container">
-            <div class="item1">1</div>
-            <div class="item2">2</div>
-            <div class="item3">3</div>
-            <div class="item4">4</div>
-            <div class="item5">5</div>
             {% for scrap in object_list %}
                 <div>
                     <a href="{% url 'scrapapp:detail' pk=scrap.pk %}">
-                        {{ scrap.beer_name }}
+                        {% include 'snippets/card_blocklist.html' with scrap=scrap %}
                     </a>
                 </div>
             {% endfor %}

--- a/scraplistapp/urls.py
+++ b/scraplistapp/urls.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.conf.urls.static import static
 from django.urls import path
 from django.views.generic import TemplateView
 
@@ -12,4 +14,4 @@ urlpatterns = [
     path('block/', TemplateView.as_view(
         template_name='scraplistapp/list_block.html'), name='block'),
     path('list/', ScraplistListView.as_view(), name='list'),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/templates/snippets/card_blocklist.html
+++ b/templates/snippets/card_blocklist.html
@@ -1,0 +1,6 @@
+<div style="display: block; text-align: center; over-fit: cover">
+    <img src="{{ scrap.picture.url }}" alt="">
+    <h6>
+       {{ scrap.beer_name }}
+    </h6>
+</div>


### PR DESCRIPTION
- 제목만 보여주는 것 말고 각 요소를 상단, 하단으로 나누어 상단에 이미지, 하단에 제목을 출력