### PR TITLE
BeerNode-111 - Fixed: scrap create view에서 지도 검색시 페이지 reload 방지

### DIFF
--- a/django/scrapapp/templates/scrapapp/map.html
+++ b/django/scrapapp/templates/scrapapp/map.html
@@ -47,7 +47,7 @@
         <div class="option">
             <div>
                 키워드 : <input type="text" value="이태원 맛집" id="keyword" size="15">
-                <button type="submit" onclick="
+                <button type="button" onclick="
                     searchPlaces();">
                     검색하기
                 </button>


### PR DESCRIPTION
- scrap create view에서 지도 검색을 하면 페이지가 reload되며 아직 입력하지 않은 field가 있다는 경고문 출력됨
- create_form.html에서 <button>의 type을 button으로 변경하여 해결