### PR TITLE
BeerNode-122 - Fixed: create 불가 현상 수정

### DIFF
--- a/django/scrapapp/templates/scrapapp/create_form.html
+++ b/django/scrapapp/templates/scrapapp/create_form.html
@@ -64,6 +64,12 @@
                 </td>
             </tr>
             <tr>
+                <th>{{ form.rating.label_tag }}</th>
+                <td>
+                    {{ form.rating }}
+                </td>
+            </tr>
+            <tr>
                 <th>{{ form.picture.label_tag }}</th>
                 <td>
                     {{ form.picture }}


### PR DESCRIPTION
- create_form.html에 rating 관련 데이터가 없어 필수 field 값을 달라고 django가 조용히 외치는 것 확인
- rating 추가로 고요한 외침을 잠재워줌