### PR TITLE
Beernode-141 - Fixed: debug_toolbar duplicate 문제 해결

### DIFF
--- a/django/beernode/settings.py
+++ b/django/beernode/settings.py
@@ -58,12 +58,12 @@ INSTALLED_APPS = [
     # thirds apps
     'bootstrap4',
     'debug_toolbar',
+    'django_filters',
     # locals apps
     'scraplistapp',
     'accountapp',
     'profileapp',
     'scrapapp',
-    'django_filters',
 ]
 
 MIDDLEWARE = [
@@ -75,7 +75,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
 INTERNAL_IPS = [


### PR DESCRIPTION
- middleware 수정: debug_toolbar 내용이 가장 위에 올라오도록 수정
- installed apps 수정: debug_toolbar가 두 번 정의되어있어 이것을 수정, django_filters는 thirds apps로 이동
- pip install django-default-imagefield 패키지 설치 필요