### PR TITLE
Beernode-99 - Completed: 액세스가 거부되는 경우 메인화면으로 redirect

### DIFF
--- a/django/scrapapp/decorators.py
+++ b/django/scrapapp/decorators.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseForbidden
+from django.shortcuts import render
 
 from scrapapp.models import Scrap
 
@@ -7,7 +7,7 @@ def scrap_ownership_required(func):
     def decorated(request, *args, **kwargs):
         scrap = Scrap.objects.get(pk=kwargs['pk'])
         if not scrap.writer == request.user:
-            return HttpResponseForbidden()
+            return render(request, template_name='403.html')
         else:
             return func(request, *args, **kwargs)
     return decorated

--- a/django/templates/403.html
+++ b/django/templates/403.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load bootstrap4 %}
+{% block content %}
+<div>
+</div>
+<script>
+    window.setTimeout(function(){
+        alert('부적절한 사용자입니다.');
+        var link = 'http://127.0.0.1:8000/';
+        location.href= link;
+    }, 200);
+</script>
+{% endblock %}


### PR DESCRIPTION
- decorators.py에서 액세스가 거부되는 경우 HttpResponseForbidden()으로 403을 던지는 대신 render()로 403.html을 던지도록 함.