### PR TITLE
Beernode-121 - Fixed: django_fields 제거, fields.py를 이용하여 default image 설정

### DIFF
--- a/django/scrapapp/migrations/0014_auto_20210318_1416.py
+++ b/django/scrapapp/migrations/0014_auto_20210318_1416.py
@@ -2,7 +2,8 @@
 
 import django.core.validators
 from django.db import migrations, models
-import django_fields.fields
+
+import scrapapp
 
 
 class Migration(migrations.Migration):
@@ -35,7 +36,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='scrap',
             name='picture',
-            field=django_fields.fields.DefaultStaticImageField(blank=True, null=True, upload_to='scrap/', verbose_name='사진'),
+            field=scrapapp.fields.DefaultStaticImageField(blank=True, null=True, upload_to='scrap/', verbose_name='사진'),
         ),
         migrations.AlterField(
             model_name='scrap',

--- a/django/scrapapp/models.py
+++ b/django/scrapapp/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
-from django_fields import DefaultStaticImageField
+from scrapapp.fields import DefaultStaticImageField
 
 
 class Scrap(models.Model):


### PR DESCRIPTION
- django_fields로 돌아가는 부분을 scrapapp.fields 파일로 대체했습니다.
- scrapapp의 migration file 중 14번이 django_fields를 사용하길래, scrapapp.fields로 임의로 수정했습니다. 웹이 작동은 잘 되지만 혹시나 나중에 문제가 생긴다면 이게 잘못일수도....

- 기존 설치된 패키지는 pip uninstall django-default-imagefield로 제거해주세요.

Resolved #121 